### PR TITLE
.Rbuildignore .travis.yml

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -7,3 +7,4 @@
 ^fig
 ^img
 ^data-raw$
+^\.travis\.yml$


### PR DESCRIPTION
To eliminate the NOTE

❯ checking for hidden files and directories ... NOTE
  Found the following hidden files and directories:
    .travis.yml
  These were most likely included in error. See section ‘Package
  structure’ in the ‘Writing R Extensions’ manual.
